### PR TITLE
공통 Button 컴포넌트 구현

### DIFF
--- a/src/components/common/Button/Button.style.ts
+++ b/src/components/common/Button/Button.style.ts
@@ -1,0 +1,16 @@
+import type { ButtonProps } from "./Button";
+
+export const buttonStyle =
+	"w-full h-full flex justify-center items-center rounded-button p-[var(--spacing-16)]";
+
+export const getButtonStateStyle = (
+	disabled: Required<ButtonProps>["disabled"]
+) => {
+	return disabled
+		? "bg-bg-disabled text-text-gray"
+		: "bg-bg-buttonPrimary text-white cursor-pointer hover:bg-bg-hover-buttonPrimary";
+};
+
+export const getButtonSizeStyle = (size: Required<ButtonProps>["size"]) => {
+	return size === "lg" ? "text-heading-h6" : "text-body-md";
+};

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -1,0 +1,29 @@
+import * as styles from "./Button.style";
+
+export interface ButtonProps {
+	label: string;
+	type?: "button" | "submit";
+	size?: "lg" | "sm";
+	disabled?: boolean;
+	onClick: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+const Button = ({
+	label,
+	type = "button",
+	size = "lg",
+	disabled = false,
+	onClick,
+}: ButtonProps) => {
+	return (
+		<button
+			className={`${styles.buttonStyle} ${styles.getButtonStateStyle(disabled)} ${styles.getButtonSizeStyle(size)}`}
+			type={type === "submit" ? "submit" : "button"}
+			disabled={disabled}
+			onClick={onClick}>
+			{label}
+		</button>
+	);
+};
+
+export default Button;


### PR DESCRIPTION
## 📝변경 사항

> 관련 이슈: https://github.com/Ureca-2th-FE-Matdori/Matdori-frontend/issues/5

- 공통 Button 컴포넌트 구현
- Button 스타일 관련 코드 분리
- 조건부 Button 스타일을 위한 getButtonStateStyle, getButtonSizeStyle 함수 구현

## 🤔리뷰 요구사항

> 공통 Button 컴포넌트를 포함한 전박적인 컴포넌트들의 반응형 대응을 위해, 컴포넌트의 width, height 속성을 full size로 지정 후 실제 크기 제어는 컴포넌트를 감싸는 부모 요소에서 담당하는 방식으로 스타일을 적용하는 방법에 대해 의견 부탁드립니다!

## 스크린샷
![image](https://github.com/user-attachments/assets/aa968c56-a01e-4dc3-bcb9-e37ec1ee500d)
