### PR TITLE
Toast 컴포넌트 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,8 @@ import { useDispatch } from "react-redux";
 import { useMediaQuery } from "react-responsive";
 import { Outlet, useLocation } from "react-router-dom";
 import GlobalNavigationBar from "@components/common/GlobalNavigationBar/GlobalNavigationBar";
+import { setUserId } from "@stores/slices/userSlice";
 import { IsMobileContext } from "@stores/IsMobileContext";
-import { setUserId } from "@stores/userSlice";
 import { PATH } from "@constants/path";
 import "./App.css";
 
@@ -15,12 +15,14 @@ function App() {
 	const isNavigationBarVisible = [PATH.PICKUP, PATH.HISTORY].some((path) =>
 		location.pathname.includes(path)
 	);
+
 	useEffect(() => {
 		const storeId = sessionStorage.getItem("userId");
 		if (storeId) {
 			dispatch(setUserId(storeId));
 		}
 	}, []);
+
 	return (
 		<IsMobileContext.Provider value={isMobile}>
 			<div className="w-full h-full flex flex-col">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useDispatch } from "react-redux";
 import { useMediaQuery } from "react-responsive";
 import { Outlet, useLocation } from "react-router-dom";
 import GlobalNavigationBar from "@components/common/GlobalNavigationBar/GlobalNavigationBar";
+import ToastContainer from "@components/common/ToastContainer/ToastContainer";
 import { setUserId } from "@stores/slices/userSlice";
 import { IsMobileContext } from "@stores/IsMobileContext";
 import { PATH } from "@constants/path";
@@ -25,11 +26,12 @@ function App() {
 
 	return (
 		<IsMobileContext.Provider value={isMobile}>
-			<div className="w-full h-full flex flex-col">
+			<div className="w-full h-full flex flex-col justify-center items-center">
 				{isNavigationBarVisible && <GlobalNavigationBar />}
 				<main>
 					<Outlet />
 				</main>
+				<ToastContainer />
 			</div>
 		</IsMobileContext.Provider>
 	);

--- a/src/assets/success-circle.svg
+++ b/src/assets/success-circle.svg
@@ -1,0 +1,11 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="40" cy="40" r="40" fill="#34C35D"/>
+<g clip-path="url(#clip0_486_20329)">
+<path d="M32.5 50.425L22.075 40L18.525 43.525L32.5 57.5L62.5 27.5L58.975 23.975L32.5 50.425Z" fill="white"/>
+</g>
+<defs>
+<clipPath id="clip0_486_20329">
+<rect width="60" height="60" fill="white" transform="translate(10 10)"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/assets/warning-circle.svg
+++ b/src/assets/warning-circle.svg
@@ -1,0 +1,12 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="40" cy="40" r="40" fill="#FFC100"/>
+<g clip-path="url(#clip0_486_20330)">
+<path d="M40 61C42.2091 61 44 59.2091 44 57C44 54.7909 42.2091 53 40 53C37.7909 53 36 54.7909 36 57C36 59.2091 37.7909 61 40 61Z" fill="white"/>
+<path d="M36 18H44V48H36V18Z" fill="white"/>
+</g>
+<defs>
+<clipPath id="clip0_486_20330">
+<rect width="60" height="60" fill="white" transform="translate(10 10)"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/common/Toast/Toast.style.ts
+++ b/src/components/common/Toast/Toast.style.ts
@@ -1,0 +1,12 @@
+import type { ToastProps } from "./Toast";
+
+export const toastStyle =
+	"flex justify-center items-center rounded-button gap-[var(--spacing-12)] p-[var(--spacing-16)] text-white";
+
+export const getVariantStyle = (variant: Required<ToastProps>["variant"]) => {
+	return variant === "Success" ? "bg-bg-buttonPrimary" : "bg-red-400";
+};
+
+export const getActiveStyle = (isActive: Required<ToastProps>["isActive"]) => {
+	return isActive ? "animate-slide-up" : "animate-slide-down";
+};

--- a/src/components/common/Toast/Toast.tsx
+++ b/src/components/common/Toast/Toast.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react";
+import useToast from "@hooks/useToast";
+import Success from "@assets/success-circle.svg";
+import Warning from "@assets/warning-circle.svg";
+import * as style from "./Toast.style";
+
+export interface ToastProps {
+	variant: "Success" | "Warning";
+	message: string;
+	isActive: boolean;
+}
+
+const Toast = ({ variant, message, isActive }: ToastProps) => {
+	const ref = useRef<HTMLDivElement>(null);
+	const { removeToast } = useToast();
+
+	useEffect(() => {
+		if (isActive || ref.current === null) return;
+
+		ref.current.getAnimations().forEach((animation) => {
+			// eslint-disable-next-line no-param-reassign
+			animation.onfinish = () => {
+				removeToast();
+			};
+		});
+	}, [isActive, removeToast]);
+
+	return (
+		<div
+			ref={ref}
+			className={`${style.toastStyle} ${style.getVariantStyle(variant)} ${style.getActiveStyle(isActive)}`}>
+			<img
+				className="w-[20px], h-[20px]"
+				src={variant === "Success" ? Success : Warning}
+				alt="Toast"
+			/>
+			<p>{message}</p>
+		</div>
+	);
+};
+
+export default Toast;

--- a/src/components/common/ToastContainer/ToastContainer.tsx
+++ b/src/components/common/ToastContainer/ToastContainer.tsx
@@ -1,0 +1,19 @@
+import { useSelector } from "react-redux";
+import Toast from "@components/common/Toast/Toast";
+import type { RootState } from "@stores/index";
+
+const ToastContainer = () => {
+	const { variant, message, isVisible, isActive } = useSelector(
+		(state: RootState) => state.rootReducer.toast
+	);
+
+	return (
+		<div className="fixed bottom-[50px] z-2">
+			{isVisible && (
+				<Toast variant={variant} message={message} isActive={isActive} />
+			)}
+		</div>
+	);
+};
+
+export default ToastContainer;

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,22 @@
+import { useDispatch } from "react-redux";
+import {
+	setToast,
+	deactivateToast,
+	removeToast,
+} from "@stores/slices/toastSlice";
+
+const useToast = () => {
+	const dispatch = useDispatch();
+
+	const makeToast = (variant: "Success" | "Warning", message: string) => {
+		dispatch(setToast({ variant, message }));
+
+		setTimeout(() => {
+			dispatch(deactivateToast());
+		}, 3000);
+	};
+
+	return { makeToast, removeToast: () => dispatch(removeToast()) };
+};
+
+export default useToast;

--- a/src/index.css
+++ b/src/index.css
@@ -79,6 +79,40 @@
 	--shadow-4: 0 0 1px rgba(0, 0, 0, 0.25), 0 4px 10px rgba(0, 0, 0, 0.1);
 }
 
+@keyframes slideUp {
+	0% {
+		transform: translate3d(0, 100%, 0);
+		opacity: 0;
+	}
+
+	100% {
+		transform: translate3d(0, 0, 0);
+		opacity: 1;
+	}
+}
+
+@keyframes slideDown {
+	0% {
+		transform: translate3d(0, 0, 0);
+		opacity: 1;
+	}
+
+	100% {
+		transform: translate3d(0, 100%, 0);
+		opacity: 0;
+	}
+}
+
+.animate-slide-up {
+	animation: slideUp 0.4s ease-out forwards;
+	will-change: transform, opacity;
+}
+
+.animate-slide-down {
+	animation: slideDown 0.4s ease-out forwards;
+	will-change: transform, opacity;
+}
+
 @font-face {
 	font-family: "CookieRun-Regular";
 	src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2001@1.1/CookieRun-Regular.woff")

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import postLogin from "@apis/user/postLogin";
 import Button from "@components/common/Button/Button";
 import LoginInput from "@components/common/logininput/loginInput";
-import { setUserId } from "@stores/userSlice";
+import { setUserId } from "@stores/slices/userSlice";
 import { PATH } from "@constants/path";
 import loginBackground from "@assets/loginBackground.png";
 import * as styles from "./LoginPage.style";
@@ -42,10 +42,10 @@ const LoginPage = () => {
 
 		try {
 			const response = await postLogin({ id, pw });
-      
+
 			sessionStorage.setItem("userId", response.userId);
 			dispatch(setUserId(response.userId));
-			nav(PATH.MAIN);
+			nav(PATH.PICKUP);
 		} catch (error) {
 			setErrorMessage("아이디 또는 비밀번호가 잘못 되었습니다.");
 		}

--- a/src/pages/SignupPage/SignupPage.tsx
+++ b/src/pages/SignupPage/SignupPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import postSignUp from "@apis/user/postSignup";
 import Button from "@components/common/Button/Button";
 import LoginInput from "@components/common/logininput/loginInput";
+import useToast from "@hooks/useToast";
 import { PATH } from "@constants/path";
 import loginBackground from "@assets/loginBackground.png";
 import * as styles from "./SignupPage.style";
@@ -13,6 +14,7 @@ const SignupPage = () => {
 	const [pw, setPW] = useState<string>("");
 	const [errorMessage, setErrorMessage] = useState<string>("");
 	const [pwConfirm, setPwconfirm] = useState<string>("");
+	const { makeToast } = useToast();
 
 	const idref = useRef<HTMLInputElement>(null);
 	const pwref = useRef<HTMLInputElement>(null);
@@ -65,7 +67,7 @@ const SignupPage = () => {
 		try {
 			await postSignUp({ id, pw });
 
-			alert("회원가입 성공하였습니다.");
+			makeToast("Success", "회원가입이 완료되었습니다.");
 			nav(PATH.LOGIN);
 		} catch (error) {
 			setErrorMessage("이미 존재하는 아이디입니다.");

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,9 +1,15 @@
-import { configureStore } from "@reduxjs/toolkit";
-import userReducer from "./userSlice";
+import { configureStore, combineReducers } from "@reduxjs/toolkit";
+import toastReducer from "@stores/slices/toastSlice";
+import userReducer from "@stores/slices/userSlice";
+
+const rootReducer = combineReducers({
+	user: userReducer,
+	toast: toastReducer,
+});
 
 export const store = configureStore({
 	reducer: {
-		user: userReducer,
+		rootReducer,
 	},
 });
 

--- a/src/stores/slices/toastSlice.ts
+++ b/src/stores/slices/toastSlice.ts
@@ -1,0 +1,43 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+interface ToastState {
+	variant: "Success" | "Warning";
+	message: string;
+	isVisible: boolean;
+	isActive: boolean;
+}
+
+const initialState: ToastState = {
+	variant: "Success",
+	message: "",
+	isVisible: false,
+	isActive: false,
+};
+
+const toastSlice = createSlice({
+	name: "Toast",
+	initialState,
+	reducers: {
+		setToast: (
+			state,
+			action: PayloadAction<Pick<ToastState, "variant" | "message">>
+		) => {
+			/* eslint-disable no-param-reassign */
+			state.variant = action.payload.variant;
+			state.message = action.payload.message;
+			state.isVisible = true;
+			state.isActive = true;
+		},
+
+		deactivateToast: (state) => {
+			state.isActive = false;
+		},
+
+		removeToast: (state) => {
+			state.isVisible = false;
+		},
+	},
+});
+
+export const { setToast, deactivateToast, removeToast } = toastSlice.actions;
+export default toastSlice.reducer;

--- a/src/stores/slices/userSlice.ts
+++ b/src/stores/slices/userSlice.ts
@@ -17,6 +17,7 @@ const userSlice = createSlice({
 	reducers: {
 		// userId 저장
 		setUserId: (state, action: PayloadAction<string>) => {
+			/* eslint-disable no-param-reassign */
 			state.userId = action.payload;
 		},
 		// userId 초기화


### PR DESCRIPTION
## 📝변경 사항

> 관련 이슈: https://github.com/Ureca-2th-FE-Matdori/Matdori-frontend/issues/22
> 사용자 피드백을 위한 Toast 컴포넌트 구현

- toast 상태 관리를 위한 Redux Toolkit 기반의 toastSlice 구현
- dispatch 중복을 줄이고 재사용성을 높이기 위한 커스텀 훅(useToast) 구현
- toast 메시지에 사용되는 아이콘 및 애니메이션 추가
- toast 메시지의 렌더링 위치를 제어하기 위한 ToastContainer 컴포넌트 구현

## 🤔리뷰 요구사항

**사용법**
```typescript
import useToast from "@hooks/useToast";

const { makeToast } = useToast();

// 토스트 메시지 생성
makeToast("Success", "회원가입이 완료되었습니다.");
```
- `makeToast`
    - variant: 토스트 메시지의 유형을 지정합니다. "Success" 또는 "Warning" 중 하나를 사용할 수 있습니다.
    - message: 사용자에게 전달할 메시지 문자열입니다.

## 스크린샷
![image](https://github.com/user-attachments/assets/1f6fa08b-e6e9-4f84-84b5-192c7dad9f20)
